### PR TITLE
Process tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 CHANGELOG inspiration from http://keepachangelog.com/.
 
 ## Unreleased
+
+## [0.4.5] - October 10, 2017
 * Remove unused NullHandler
 * Extract KafkaImpl.Util.kafka_ex_worker helper function
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 CHANGELOG inspiration from http://keepachangelog.com/.
 
 ## Unreleased
+* Remove unused NullHandler
+* Extract KafkaImpl.Util.kafka_ex_worker helper function
 
 ## [0.4.4] - August 30, 2017
 * Rename @impl attribute for Elixir 1.5 compatibility

--- a/lib/kafka_impl/kafka_mock.ex
+++ b/lib/kafka_impl/kafka_mock.ex
@@ -3,8 +3,6 @@ defmodule KafkaImpl.KafkaMock do
 
   alias KafkaImpl.KafkaMock.Store
 
-  alias KafkaEx.Protocol.Fetch.Message
-
   defdelegate start_link, to: Store
 
   ## Actual Kafka interface

--- a/lib/kafka_impl/kafka_mock.ex
+++ b/lib/kafka_impl/kafka_mock.ex
@@ -3,6 +3,8 @@ defmodule KafkaImpl.KafkaMock do
 
   alias KafkaImpl.KafkaMock.Store
 
+  alias KafkaEx.Protocol.Fetch.Message
+
   defdelegate start_link, to: Store
 
   ## Actual Kafka interface
@@ -62,10 +64,11 @@ defmodule KafkaImpl.KafkaMock do
   def fetch(topic, partition, opts \\ []) do
     offset = Keyword.get(opts, :offset, 0)
 
-    records = Store.get(:messages, [])
-    |> Enum.filter(fn {^topic, ^partition, _, msg_offset} -> msg_offset >= offset; _ -> false end)
+    message_set = messages_key(topic, partition)
+    |> Store.get([])
+    |> Enum.filter(fn %{offset: msg_offset} -> msg_offset >= offset end)
 
-    last_offset = records |> Enum.reduce(nil, fn {_,_,_,msg_offset}, acc ->
+    last_offset = Enum.reduce(message_set, nil, fn %{offset: msg_offset}, acc ->
       cond do
         acc == nil -> msg_offset
         acc > msg_offset -> acc
@@ -73,27 +76,41 @@ defmodule KafkaImpl.KafkaMock do
       end
     end)
 
-    messages = records |> Enum.map(fn {_,_,msg,_} -> msg end)
-
     [%KafkaEx.Protocol.Fetch.Response{
       topic: topic,
       partitions: [
-        %{partition: partition, message_set: messages, last_offset: last_offset}
+        %{partition: partition, message_set: message_set, last_offset: last_offset}
       ]
     }]
   end
 
-  def produce(%{topic: topic, partition: partition, messages: [%{value: message}]}, _opts \\ []) do
-    Store.update(self(), fn state ->
-      key = {:produce, topic, partition}
-      existing_messages = state |> Map.get(key, [])
-      state |> Map.put(key, [message | existing_messages])
+  def produce(%KafkaEx.Protocol.Produce.Request{
+    topic: topic, partition: partition, messages: [
+      %KafkaEx.Protocol.Produce.Message{} = message
+    ]
+  }, _opts \\ []) do
+    Store.update(fn state ->
+      key = messages_key(topic, partition)
+
+      existing_records = Map.get(state, key, [])
+
+      offset = Enum.reduce(existing_records, -1, fn %{offset: offset}, acc ->
+        if offset > acc, do: offset, else: acc
+      end) + 1
+
+      record = %KafkaEx.Protocol.Fetch.Message{
+        value: message.value,
+        offset: offset
+      }
+
+      state
+      |> Map.put(key, [record | existing_records])
     end)
   end
 
   def offset_commit(_worker, %{consumer_group: consumer_group, topic: topic, partition: partition, offset: offset}) do
-    Store.update(self(), fn state ->
-      state |> Map.put({:offset_commit, consumer_group, topic, partition}, offset)
+    Store.update(fn state ->
+      Map.put(state, {:offset_commit, consumer_group, topic, partition}, offset)
     end)
 
     %KafkaEx.Protocol.OffsetCommit.Response{topic: topic, partitions: [offset]}
@@ -110,5 +127,9 @@ defmodule KafkaImpl.KafkaMock do
         ]
       }
     ]
+  end
+
+  defp messages_key(topic, partition) do
+    {:produce, topic, partition}
   end
 end

--- a/lib/kafka_impl/kafka_mock/store.ex
+++ b/lib/kafka_impl/kafka_mock/store.ex
@@ -1,22 +1,61 @@
 defmodule KafkaImpl.KafkaMock.Store do
-  def start_link, do: Agent.start_link(fn -> %{} end, name: __MODULE__)
+  @agent_name __MODULE__
+
+  def start_link do
+    {:ok, pid} = Agent.start_link(fn -> %{} end, name: @agent_name)
+    register_storage_pid(self())
+    {:ok, pid}
+  end
 
   def get(key, default) do
     get(key, default, self())
   end
-  def get(key, default, pid) do
-    case Process.whereis(__MODULE__) do
+  def get(key, default, requesting_pid) do
+    case Process.whereis(@agent_name) do
       nil -> default
       _ ->
-        Agent.get(__MODULE__, fn state ->
-          state |> Map.get(pid, %{}) |> Map.get(key, default)
+        Agent.get(@agent_name, fn state ->
+          case get_storage_pid(requesting_pid, Map.keys(state)) do
+            {:ok, pid} ->
+              state
+              |> Map.get(pid, %{})
+              |> Map.get(key, default)
+            _ -> nil
+          end
         end)
     end
   end
 
-  def update(pid, func) do
-    Agent.update(__MODULE__, fn state ->
-      state |> Map.update(pid, func.(%{}), func)
+  def update(func) do
+    requesting_pid = self()
+    Agent.update(@agent_name, fn state ->
+      case get_storage_pid(requesting_pid, Map.keys(state)) do
+        {:ok, pid} ->
+          Map.update(state, pid, func.(%{}), func)
+        _ -> state
+      end
     end)
+  end
+
+  def register_storage_pid(pid) do
+    Agent.update(@agent_name, fn state ->
+      Map.put_new(state, pid, %{})
+    end)
+  end
+
+  def get_storage_pid(child_pid, registered_pids) do
+    ancestors = [child_pid | get_ancestors(child_pid)]
+
+    Enum.find(registered_pids, fn registered_pid ->
+      Enum.any?(ancestors, & &1 == registered_pid)
+    end)
+    |> (&{:ok, &1}).()
+  end
+
+  defp get_ancestors(pid) do
+    case Process.info(pid, [:dictionary]) do
+      [dictionary: dictionary] -> Keyword.get(dictionary, :"$ancestors")
+      _ -> :error
+    end
   end
 end

--- a/lib/kafka_impl/kafka_mock/store.ex
+++ b/lib/kafka_impl/kafka_mock/store.ex
@@ -2,9 +2,7 @@ defmodule KafkaImpl.KafkaMock.Store do
   @agent_name __MODULE__
 
   def start_link do
-    {:ok, pid} = Agent.start_link(fn -> %{} end, name: @agent_name)
-    register_storage_pid(self())
-    {:ok, pid}
+    Agent.start_link(fn -> %{} end, name: @agent_name)
   end
 
   def get(key, default) do
@@ -54,8 +52,8 @@ defmodule KafkaImpl.KafkaMock.Store do
 
   defp get_ancestors(pid) do
     case Process.info(pid, [:dictionary]) do
-      [dictionary: dictionary] -> Keyword.get(dictionary, :"$ancestors")
-      _ -> :error
+      [dictionary: dictionary] -> Keyword.get(dictionary, :"$ancestors", [])
+      _ -> []
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,8 @@ defmodule KafkaImpl.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [extra_applications: [:logger],
+     applications: []]
   end
 
   defp deps do

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule KafkaImpl.Mixfile do
       elixir: "~> 1.4",
       package: package(),
       start_permanent: Mix.env == :prod,
-      version: "0.4.4"
+      version: "0.4.5"
     ]
   end
 

--- a/test/kafka_mock_test.exs
+++ b/test/kafka_mock_test.exs
@@ -30,6 +30,7 @@ defmodule KafkaImpl.KafkaMockTest do
 
   setup do
     KafkaMock.start_link
+    KafkaMock.Store.register_storage_pid(self())
 
     :ok
   end

--- a/test/kafka_mock_test.exs
+++ b/test/kafka_mock_test.exs
@@ -3,12 +3,33 @@ defmodule KafkaImpl.KafkaMockTest do
 
   alias KafkaImpl.KafkaMock
   alias KafkaImpl.KafkaMock.TestHelper
+  alias KafkaEx.Protocol.Fetch.Message, as: FetchMessage
+
+  defmodule TestProcess do
+    use GenServer
+
+    def start_link(func \\ (fn -> nil end)) do
+      GenServer.start_link(__MODULE__, func)
+    end
+
+    def init(func) do
+      func.()
+      {:ok, func}
+    end
+
+    def handle_info({:spawn_child, func}, state) do
+      {:ok, _} = start_link(func)
+      {:noreply, state}
+    end
+  end
+
+  defp new_link() do
+    {:ok, pid} = TestProcess.start_link()
+    pid
+  end
 
   setup do
-    :ok = case KafkaMock.start_link do
-      {:ok, _mock} -> :ok
-      {:error, {:already_started, _pid}} -> :ok
-    end
+    KafkaMock.start_link
 
     :ok
   end
@@ -16,7 +37,7 @@ defmodule KafkaImpl.KafkaMockTest do
   describe "metadata" do
     test "can set and retrieve topics" do
       assert [] == KafkaMock.metadata.topic_metadatas
-      TestHelper.set_topics(self(), ["foo", "bar"])
+      TestHelper.set_topics(["foo", "bar"])
       assert ["foo", "bar"] == KafkaMock.metadata.topic_metadatas |>
         Enum.map(& Map.get(&1, :topic))
     end
@@ -33,9 +54,9 @@ defmodule KafkaImpl.KafkaMockTest do
   describe "fetch" do
     test "can set and retrieve messaages" do
       topic = "foo"
-      offset = 100
+      offset = 0
       partition = 0
-      message = "the message"
+      message = %FetchMessage{value: "the message", offset: offset}
 
       assert [%KafkaEx.Protocol.Fetch.Response{
         topic: topic,
@@ -44,7 +65,9 @@ defmodule KafkaImpl.KafkaMockTest do
         ]
       }] == KafkaMock.fetch(topic, partition, offset: offset)
 
-      TestHelper.send_message(self(), {topic, partition, message, offset})
+      TestHelper.send_messages(topic, partition, [
+        message
+      ])
 
       assert [%KafkaEx.Protocol.Fetch.Response{
         topic: topic,
@@ -56,10 +79,10 @@ defmodule KafkaImpl.KafkaMockTest do
 
     test "can receive multiple messages" do
       topic = "foo"
-      offset = 100
+      offset = 0
       partition = 0
-      message1 = "the message"
-      message2 = "second message"
+      message1 = %FetchMessage{value: "the message", offset: offset}
+      message2 = %FetchMessage{value: "second message", offset: offset+1}
 
       assert [%KafkaEx.Protocol.Fetch.Response{
         topic: topic,
@@ -68,23 +91,26 @@ defmodule KafkaImpl.KafkaMockTest do
         ]
       }] == KafkaMock.fetch(topic, partition, offset: offset)
 
-      TestHelper.send_messages(self(), [
-        {topic, partition, message1, offset},
-        {topic, partition, message2, offset+1}
-      ])
+      TestHelper.send_messages(topic, partition, [ message1, message2 ])
+
+      expected_offset = offset + 1
 
       assert [%KafkaEx.Protocol.Fetch.Response{
-        topic: topic,
+        topic: ^topic,
         partitions: [
-          %{partition: partition, message_set: [message1, message2], last_offset: offset+1}
+          %{
+            partition: ^partition,
+            message_set: [^message1, ^message2],
+            last_offset: ^expected_offset
+          }
         ]
-      }] == KafkaMock.fetch(topic, partition, offset: offset)
+      }] = KafkaMock.fetch(topic, partition, offset: offset)
     end
   end
 
   test "offset_commit" do
     topic = "foo"
-    offset = 100
+    offset = 0
     assert %KafkaEx.Protocol.OffsetCommit.Response{topic: topic, partitions: [offset]} ==
       KafkaMock.offset_commit(:some_worker_pid, %{topic: topic, offset: offset, partition: 0,
         consumer_group: "kafka_impl"})
@@ -103,6 +129,35 @@ defmodule KafkaImpl.KafkaMockTest do
       }]
     } |> KafkaMock.produce
 
-    assert [^message] = TestHelper.read_messages topic, partition, self()
+    assert [^message] = TestHelper.read_messages topic, partition
+  end
+
+  test "process tree inheritance" do
+    topic = "fooz"
+    partition = 1
+    message = "okay do it"
+    request = %KafkaEx.Protocol.Produce.Request{
+      topic:         topic,
+      partition:     partition,
+      required_acks: 1,
+      messages:      [%KafkaEx.Protocol.Produce.Message{
+        value: message
+      }]
+    }
+
+    test_pid = self()
+    pid = new_link()
+    send pid, {:spawn_child, fn ->
+      KafkaMock.produce(request)
+      send test_pid, :produced
+    end}
+
+    :ok = receive do
+      :produced -> :ok
+    after
+      1000 -> raise "no message produced after 1s"
+    end
+
+    assert [^message] = TestHelper.read_messages topic, partition
   end
 end

--- a/test/store_test.exs
+++ b/test/store_test.exs
@@ -1,0 +1,121 @@
+defmodule KafkaImpl.KafkaMock.StoreTest do
+  use ExUnit.Case
+
+  alias KafkaImpl.KafkaMock.Store
+
+  defmodule TestProcess do
+    use GenServer
+
+    def start_link(func \\ (fn -> nil end)) do
+      GenServer.start_link(__MODULE__, func)
+    end
+
+    def init(func) do
+      func.()
+      {:ok, func}
+    end
+
+    def handle_info({:spawn_child, func}, state) do
+      {:ok, _} = start_link(func)
+      {:noreply, state}
+    end
+  end
+
+  defp new_link() do
+    {:ok, pid} = TestProcess.start_link()
+    pid
+  end
+
+  test "get_storage_pid for child pid" do
+    registered_pids = [
+      new_link(),
+      storage_pid = new_link(),
+      new_link(),
+    ]
+
+    test_pid = self()
+    send storage_pid, {:spawn_child, fn -> send test_pid, {:child_pid, self()} end}
+
+    child = receive do
+      {:child_pid, child} -> child
+    after
+      1000 -> raise "did not receive child pid after 1s"
+    end
+
+    assert {:ok, storage_pid} == Store.get_storage_pid(child, registered_pids)
+  end
+
+  test "get_storage_pid for self" do
+    registered_pids = [
+      new_link(),
+      storage_pid = new_link(),
+      new_link(),
+    ]
+
+    send storage_pid, {:spawn_child, self()}
+
+    assert {:ok, storage_pid} == Store.get_storage_pid(storage_pid, registered_pids)
+  end
+
+  test "registering a pid is used for storage" do
+    Store.start_link
+
+    parent = new_link()
+    test_pid = self()
+
+    send parent, {:spawn_child, fn ->
+      Store.update(fn state ->
+        Map.put(state, :foo, "bar")
+      end)
+      send test_pid, :proceed
+    end}
+
+    receive do
+      :proceed -> :ok
+    after
+      100 -> raise "didn't get the message to proceed"
+    end
+
+    assert "bar" == Store.get(:foo, nil)
+  end
+
+  test "get looks up the parent for storage" do
+    Store.start_link
+
+    parent = new_link()
+
+    Store.update(fn state ->
+      Map.put(state, :foo, "bar")
+    end)
+
+    send parent, {:spawn_child, fn ->
+      assert "bar" == Store.get(:foo, nil)
+    end}
+  end
+
+  test "both update and get in children" do
+    Store.start_link
+
+    parent1 = new_link()
+    test_pid = self()
+
+    send parent1, {:spawn_child, fn ->
+      Store.update(fn state ->
+        Map.put(state, :foo, "bar")
+      end)
+      send test_pid, :proceed
+    end}
+
+    receive do
+      :proceed -> :ok
+    after
+      100 -> raise "didn't get the message to proceed"
+    end
+
+    parent2 = new_link()
+
+    send parent2, {:spawn_child, fn ->
+      assert "bar" == Store.get(:foo, nil)
+    end}
+  end
+end


### PR DESCRIPTION
Change Store to bucket state onto set pids. That way a process tree can use the same Store bucket.

```
         TestProcess
          /       \
         /         \
KafkaMock.Store   Consumer/Producer worker
```

So the producer puts messages in a Store that the Consumer can read. Without having to tell either about the pid.